### PR TITLE
Made payment optional in ReturnRequest 

### DIFF
--- a/src/Returns/Http/Requests/ReturnRequest.php
+++ b/src/Returns/Http/Requests/ReturnRequest.php
@@ -33,7 +33,7 @@ class ReturnRequest extends FormRequest
         return Address::from($this->input('data.return_address'));
     }
 
-    public function payment(): ReturnPayment
+    public function payment(): ReturnPayment|null
     {
         return ReturnPayment::from($this->input('data.payment'));
     }


### PR DESCRIPTION
Following a discussion with @M4tini We concluded that payments might not always be set when issueing returns. Therefor the `payment` in the `ReturnRequest` should be optional