### PR TITLE
:fire: Remove `min:1` return reasons validation rule

### DIFF
--- a/src/Shop/Http/Requests/CreateConfigurationFormRequest.php
+++ b/src/Shop/Http/Requests/CreateConfigurationFormRequest.php
@@ -29,4 +29,11 @@ class CreateConfigurationFormRequest extends FormRequest
             'data.return_reasons.*.label' => 'required|string',
         ];
     }
+
+    public function messages(): array
+    {
+        return [
+            'data.return_reasons' => 'Your shop requires at least one linked return reason.',
+        ];
+    }
 }


### PR DESCRIPTION
It is not required to have return reasons linked to your shop in MyParcel.com to create a return in a WMS (we use the default return reason there)