### PR TITLE
:sparkles: Replace ConfigureRequest validation rule `required` with `present`

### DIFF
--- a/src/Configuration/Http/Requests/ConfigureRequest.php
+++ b/src/Configuration/Http/Requests/ConfigureRequest.php
@@ -12,7 +12,7 @@ class ConfigureRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'data' => 'required|array',
+            'data' => 'present|array',
         ];
     }
 


### PR DESCRIPTION
Reason is that the `required` rule fails when you submit an "empty" value, like `[]`, while this is a valid value. The validation of the request data can only be done in the controller action because it requires an instance of the JSON Schema settings form